### PR TITLE
Update github-repo urls (because of the repository name change)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/webscopeio/mailingui-web",
+    "url": "https://github.com/webscopeio/mailingui",
     "directory": "packages/cli"
   },
   "license": "MIT",

--- a/src/app/(with-navbar)/feedback/page.tsx
+++ b/src/app/(with-navbar)/feedback/page.tsx
@@ -40,14 +40,14 @@ export default function FeedbackPage() {
         </p>
         <div className="mt-8 w-full md:flex md:gap-4">
           <CTA
-            href={"https://github.com/webscopeio/mailingui-web/issues"}
+            href={"https://github.com/webscopeio/mailingui/issues"}
             color="white"
             className="w-full md:w-auto"
           >
             Report an issue
           </CTA>
           <CTA
-            href={"https://github.com/webscopeio/mailingui-web/discussions"}
+            href={"https://github.com/webscopeio/mailingui/discussions"}
             color="black"
             className="w-full md:w-auto"
           >

--- a/src/docs/blog/001.mdx
+++ b/src/docs/blog/001.mdx
@@ -43,4 +43,4 @@ To get started with Mailing UI, simply visit the library from our website or Git
 
 We believe that Mailing UI will be a valuable resource for anyone looking to improve their email campaigns. Email is still one of the most effective ways to reach your audience, and Mailing UI can help make that process easier and more efficient.
 
-We've launched early because we want to get feedback, and we'd really appreciate it if you could provide us with some on [Twitter](https://twitter.com/MailingUI) or using [Github Discussions](https://github.com/webscopeio/mailingui-web/discussions).
+We've launched early because we want to get feedback, and we'd really appreciate it if you could provide us with some on [Twitter](https://twitter.com/MailingUI) or using [Github Discussions](https://github.com/webscopeio/mailingui/discussions).

--- a/src/docs/components/Greeting/Greeting.tsx
+++ b/src/docs/components/Greeting/Greeting.tsx
@@ -45,7 +45,7 @@ export const Greeting = () => (
           Get started
         </CTA>
         <CTA
-          href="https://github.com/webscopeio/mailingui-web/stargazers"
+          href="https://github.com/webscopeio/mailingui/stargazers"
           target="_blank"
           rel="noopener"
           color="black"

--- a/src/docs/constants/links.ts
+++ b/src/docs/constants/links.ts
@@ -17,7 +17,7 @@ export const navigationLinks = [
 
 export const socialLinks = [
   {
-    href: "https://github.com/webscopeio/mailingui-web",
+    href: "https://github.com/webscopeio/mailingui",
     label: "GitHub",
     Icon: GitHubIcon,
   },


### PR DESCRIPTION
Every `mailingui-web` link is now changed to just `mailingui`.