### PR TITLE
Add BulletList to installable components

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,7 +6,6 @@ import execa from "execa";
 import ora from "ora";
 import prompts from "prompts";
 import {
-  BASE_URL,
   DEPENDENCIES as REQUIRED_DEPENDENCIES,
   SETTINGS_FILE_NAME,
 } from "../constants";
@@ -19,7 +18,7 @@ export const init = new Command()
   .option(
     "-p, --path <path>",
     "define base path to your MailingUI components",
-    "./src/@mailingui"
+    "./src/mailingui"
   )
   .option("-o, --overwrite", "overwrite existing configuration", false)
   .action(async (options) => {

--- a/packages/cli/src/utils/createFile.ts
+++ b/packages/cli/src/utils/createFile.ts
@@ -7,7 +7,7 @@ import { Component } from "../types";
 export async function createFile(
   componentName: string,
   components: Record<string, Component>,
-  basePath?: string,
+  basePath: string,
   overwrite?: boolean
 ) {
   const component = components[componentName];
@@ -16,9 +16,9 @@ export async function createFile(
     await createFile(dependency, components, basePath, overwrite);
   }
 
-  const directoryPath = basePath
-    ? `${basePath}/components/${path.basename(path.dirname(component.path))}`
-    : path.dirname(component.path);
+  const directoryPath = `${basePath}/components/${path.basename(
+    path.dirname(component.path)
+  )}`;
 
   if (!fs.existsSync(directoryPath)) {
     fs.mkdirSync(directoryPath, { recursive: true });

--- a/packages/cli/src/utils/createFile.ts
+++ b/packages/cli/src/utils/createFile.ts
@@ -1,8 +1,8 @@
 import path from "path";
-import { Component } from "../types";
 import fs from "fs";
 import prompts from "prompts";
 import chalk from "chalk";
+import { Component } from "../types";
 
 export async function createFile(
   componentName: string,
@@ -17,14 +17,16 @@ export async function createFile(
   }
 
   const directoryPath = basePath
-    ? `${basePath}/components/${componentName}`
+    ? `${basePath}/components/${path.basename(path.dirname(component.path))}`
     : path.dirname(component.path);
 
   if (!fs.existsSync(directoryPath)) {
     fs.mkdirSync(directoryPath, { recursive: true });
   }
 
-  const filepath = `${directoryPath}/${path.basename(component.path)}`;
+  const filepath = `${directoryPath}/${path.basename(
+    path.dirname(component.path)
+  )}/${path.basename(component.path)}`;
   const pathToThemes = path.relative(directoryPath, `${basePath}/themes`);
   const componentFileWithUpdateTheme = component.file.replace(
     "@mailingui/themes",

--- a/packages/cli/src/utils/createFile.ts
+++ b/packages/cli/src/utils/createFile.ts
@@ -24,9 +24,7 @@ export async function createFile(
     fs.mkdirSync(directoryPath, { recursive: true });
   }
 
-  const filepath = `${directoryPath}/${path.basename(
-    path.dirname(component.path)
-  )}/${path.basename(component.path)}`;
+  const filepath = `${directoryPath}/${path.basename(component.path)}`;
   const pathToThemes = path.relative(directoryPath, `${basePath}/themes`);
   const componentFileWithUpdateTheme = component.file.replace(
     "@mailingui/themes",

--- a/src/app/api/components/route.ts
+++ b/src/app/api/components/route.ts
@@ -12,6 +12,7 @@ type SupportedComponents =
   | "emoji"
   | "heroSection"
   | "list"
+  | "bulletList"
   | "socialIcon"
   | "text";
 
@@ -48,6 +49,10 @@ const getComponents = (): Record<
     list: {
       dependencies: [],
       ...getFileProps("./src/mailingui/components/list/List.tsx"),
+    },
+    bulletList: {
+      dependencies: [],
+      ...getFileProps("./src/mailingui/components/list/BulletList.tsx"),
     },
     socialIcon: {
       dependencies: [],

--- a/src/app/api/components/route.ts
+++ b/src/app/api/components/route.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import { NextResponse } from "next/server";
 
 const getFileProps = (path: string) => ({
   path,
@@ -72,5 +73,3 @@ export const GET = async () => {
     return NextResponse.error();
   }
 };
-
-import { NextResponse } from "next/server";


### PR DESCRIPTION
I added it as a new component - didn't find a way to include it within the `List` component, meaning that if you ran `add list` it would add both `List.tsx` and `BulletList.tsx`.

If you guys are okay with this I can merge and update the cli afterwards.