### PR TITLE
Remove 'use client'

### DIFF
--- a/src/docs/content/Installation.mdx
+++ b/src/docs/content/Installation.mdx
@@ -126,7 +126,8 @@ npx create-next-app@latest --typescript
 {
   "compilerOptions": {
     "paths": {
-      "@mailingui/components": ["src/mailingui/components/index.ts"]
+      "@mailingui/components": ["src/mailingui/components/index.ts"],
+      "@mailingui/themes": ["src/mailingui/themes/index.ts"]
     }
   }
 }

--- a/src/docs/examples/lists/CenteredVerticalList.tsx
+++ b/src/docs/examples/lists/CenteredVerticalList.tsx
@@ -14,25 +14,29 @@ export default function CenteredVerticalList() {
       <Preview>Centered Paragraph</Preview>
       <Body style={main}>
         <Container style={container}>
-          <ListRoot centered>
+          <ListRoot>
             <ListItem>
-              <ListItemTitle>Nullam interdum enim in porta</ListItemTitle>
-              <ListItemContent>
+              <ListItemTitle centered>
+                Nullam interdum enim in porta
+              </ListItemTitle>
+              <ListItemContent centered>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                 Praesent eget efficitur velit, non suscipit ipsum.
               </ListItemContent>
             </ListItem>
             <ListItem>
-              <ListItemTitle>Donec eget eros nec nunc ultricies</ListItemTitle>
-              <ListItemContent>
+              <ListItemTitle centered>
+                Donec eget eros nec nunc ultricies
+              </ListItemTitle>
+              <ListItemContent centered>
                 Praesent fermentum dolor hendrerit enim rhoncus, vitae vulputate
                 quam bibendum. Donec ac pulvinar tellus. Aliquam semper eros vel
                 justo vehicula luctus. Donec vel ex leo.
               </ListItemContent>
             </ListItem>
             <ListItem>
-              <ListItemTitle>Cras non feugiat risus</ListItemTitle>
-              <ListItemContent>
+              <ListItemTitle centered>Cras non feugiat risus</ListItemTitle>
+              <ListItemContent centered>
                 Cras vestibulum massa et erat maximus vulputate.
               </ListItemContent>
             </ListItem>

--- a/src/docs/examples/lists/CombinedLists.tsx
+++ b/src/docs/examples/lists/CombinedLists.tsx
@@ -14,8 +14,8 @@ export default function CombinedLists() {
       <Preview>Centered Paragraph</Preview>
       <Body style={main}>
         <Container style={container}>
-          <ListRoot horizontal>
-            <ListItem style={{ paddingRight: "32px" }}>
+          <ListRoot>
+            <ListItem direction="horizontal" style={{ paddingRight: "32px" }}>
               <ListItemTitle>
                 Advanced syntax highlighting solution
               </ListItemTitle>
@@ -24,7 +24,7 @@ export default function CombinedLists() {
                 by Shiki(opens in a new tab).
               </ListItemContent>
             </ListItem>
-            <ListItem>
+            <ListItem direction="horizontal">
               <ListItemTitle>I18n as easy as creating new files</ListItemTitle>
               <ListItemContent>
                 Name your page files with locales suffixed, Nextra and Next.js

--- a/src/docs/examples/lists/DifferentSizedItems.tsx
+++ b/src/docs/examples/lists/DifferentSizedItems.tsx
@@ -15,28 +15,32 @@ export default function VerticalList() {
       <Body style={main}>
         <Container style={container}>
           <ListRoot>
-            <ListItem size="xs">
-              <ListItemTitle>Nullam interdum enim in porta</ListItemTitle>
-              <ListItemContent>
+            <ListItem>
+              <ListItemTitle size="xs">
+                Nullam interdum enim in porta
+              </ListItemTitle>
+              <ListItemContent size="xs">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
               </ListItemContent>
             </ListItem>
-            <ListItem size="sm">
-              <ListItemTitle>Donec eget eros nec nunc ultricies</ListItemTitle>
-              <ListItemContent>
+            <ListItem>
+              <ListItemTitle size="sm">
+                Donec eget eros nec nunc ultricies
+              </ListItemTitle>
+              <ListItemContent size="sm">
                 Praesent fermentum dolor hendrerit enim rhoncus, vitae vulputate
                 quam bibendum. Donec ac pulvinar tellus.
               </ListItemContent>
             </ListItem>
-            <ListItem size="md">
+            <ListItem>
               <ListItemTitle>Aenean odio</ListItemTitle>
               <ListItemContent>
                 Sed feugiat nibh a ligula euismod vehicula.
               </ListItemContent>
             </ListItem>
-            <ListItem size="lg">
-              <ListItemTitle>Cras feugiat</ListItemTitle>
-              <ListItemContent>
+            <ListItem>
+              <ListItemTitle size="lg">Cras feugiat</ListItemTitle>
+              <ListItemContent size="lg">
                 Cras vestibulum massa et erat maximus vulputate.
               </ListItemContent>
             </ListItem>

--- a/src/docs/examples/lists/HorizontalList.tsx
+++ b/src/docs/examples/lists/HorizontalList.tsx
@@ -14,20 +14,20 @@ export default function CombinedLists() {
       <Preview>Centered Paragraph</Preview>
       <Body style={main}>
         <Container style={container}>
-          <ListRoot horizontal>
-            <ListItem style={{ paddingRight: "32px" }}>
+          <ListRoot>
+            <ListItem direction="horizontal" style={{ paddingRight: "32px" }}>
               <ListItemTitle>USWNT 2022/23 Stadium Home</ListItemTitle>
               <ListItemContent>
                 Women&apos;s Nike Dri-FIT Soccer Jersey
               </ListItemContent>
             </ListItem>
-            <ListItem style={{ paddingRight: "32px" }}>
+            <ListItem direction="horizontal" style={{ paddingRight: "32px" }}>
               <ListItemTitle>Brazil 2022/23 Stadium Goalkeeper</ListItemTitle>
               <ListItemContent>
                 Men&apos;s Nike Dri-FIT Short-Sleeve Football Shirt
               </ListItemContent>
             </ListItem>
-            <ListItem>
+            <ListItem direction="horizontal">
               <ListItemTitle>FFF</ListItemTitle>
               <ListItemContent>
                 Women&apos;s Nike Pre-Match Football Top

--- a/src/docs/examples/lists/SmallList.tsx
+++ b/src/docs/examples/lists/SmallList.tsx
@@ -14,30 +14,30 @@ export default function VerticalList() {
       <Preview>Centered Paragraph</Preview>
       <Body style={main}>
         <Container style={container}>
-          <ListRoot size="xs">
+          <ListRoot>
             <ListItem>
-              <ListItemTitle>
+              <ListItemTitle size="xs">
                 Using content you’ve shared publicly
               </ListItemTitle>
-              <ListItemContent>
+              <ListItemContent size="xs">
                 For example, to promote a Google app, we might quote a review
                 you wrote. Or to promote Google Play, we might show a screenshot
                 of the app you offer in the Play Store.
               </ListItemContent>
             </ListItem>
             <ListItem>
-              <ListItemTitle>
+              <ListItemTitle size="xs">
                 Developing new technologies and services
               </ListItemTitle>
-              <ListItemContent>
+              <ListItemContent size="xs">
                 For Google consistent with these terms
               </ListItemContent>
             </ListItem>
             <ListItem>
-              <ListItemTitle>
+              <ListItemTitle size="xs">
                 Operating and improving the services
               </ListItemTitle>
-              <ListItemContent>
+              <ListItemContent size="xs">
                 Which means allowing the services to work as designed and
                 creating new features and functionalities. This includes using
                 automated systems and algorithms to analyze your content

--- a/src/docs/examples/lists/ThemedList.tsx
+++ b/src/docs/examples/lists/ThemedList.tsx
@@ -23,20 +23,20 @@ export default function VerticalList() {
                 Now you can start using your account! Log in on our website.
               </ListItemContent>
             </ListItem>
-            <ListItem variant="brand">
-              <ListItemTitle>
+            <ListItem>
+              <ListItemTitle variant="brand">
                 Somebody tried to get into your account!
               </ListItemTitle>
-              <ListItemContent size="sm">
+              <ListItemContent variant="brand" size="sm">
                 You can ignore this message if you were the one who tried to get
                 into your account.
               </ListItemContent>
             </ListItem>
-            <ListItem size="xs" variant="subtle">
-              <ListItemTitle>
+            <ListItem>
+              <ListItemTitle size="xs" variant="subtle">
                 We are happy to help anytime you need
               </ListItemTitle>
-              <ListItemContent>
+              <ListItemContent size="xs" variant="subtle">
                 You can find us at our website, send us an email or in our
                 offices at 420 Wick Way New York, NY 10001 United States.
               </ListItemContent>

--- a/src/mailingui/components/badge/Badge.tsx
+++ b/src/mailingui/components/badge/Badge.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, { CSSProperties } from "react";
 import { theme } from "@mailingui/themes";
 

--- a/src/mailingui/components/button/Button.tsx
+++ b/src/mailingui/components/button/Button.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, { FC, ReactNode, CSSProperties } from "react";
 import { Button as ReactEmailButton } from "@react-email/components";
 import { theme } from "@mailingui/themes";

--- a/src/mailingui/components/divider/Divider.tsx
+++ b/src/mailingui/components/divider/Divider.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, { CSSProperties, FC, ReactNode } from "react";
 import { Hr, Section, Row, Column } from "@react-email/components";
 import { theme } from "@mailingui/themes";

--- a/src/mailingui/components/emoji/Emoji.tsx
+++ b/src/mailingui/components/emoji/Emoji.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, { FC, CSSProperties } from "react";
 import { Img, Link } from "@react-email/components";
 
@@ -7,7 +5,7 @@ interface EmojiProps {
   type: EmojiType;
   small?: boolean;
   href?: string;
-  style?: CSSProperties,
+  style?: CSSProperties;
   bg?: boolean;
 }
 
@@ -20,7 +18,7 @@ const Emoji: FC<EmojiProps> = ({ type, href, style, small, bg }) => {
         height: size,
         width: size,
         margin: bg ? undefined : "14px",
-        ...style
+        ...style,
       }}
       src={getEmojiImg(type, bg)}
       alt={type}

--- a/src/mailingui/components/hero-section/HeroSection.tsx
+++ b/src/mailingui/components/hero-section/HeroSection.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, { CSSProperties, FC } from "react";
 import {
   Heading as ReactEmailHeading,

--- a/src/mailingui/components/list/BulletList.tsx
+++ b/src/mailingui/components/list/BulletList.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import React, {
-  FC,
-  CSSProperties,
-  ReactNode,
-  createContext,
-  useContext,
-} from "react";
+import React, { FC, CSSProperties, ReactNode } from "react";
 import { theme } from "@mailingui/themes";
 
 const {
@@ -44,14 +38,6 @@ const sizes: Record<"xs" | "sm" | "md" | "lg", CSSProperties> = {
   },
 };
 
-type BulletListContextType = {
-  size: keyof typeof sizes;
-};
-
-const BulletListContext = createContext<BulletListContextType>({
-  size: "md",
-});
-
 type BulletListProps = {
   type: "unordered" | "ordered";
   style?: CSSProperties;
@@ -59,23 +45,18 @@ type BulletListProps = {
   size?: keyof typeof sizes;
 };
 
-const BulletList: FC<BulletListProps> = ({ type, size, style, children }) => {
+const BulletList: FC<BulletListProps> = ({ type, style, children }) => {
   const ListRoot = type === "unordered" ? "ul" : "ol";
-  const contextValue: BulletListContextType = {
-    size: size ?? "md",
-  };
 
   return (
-    <BulletListContext.Provider value={contextValue}>
-      <ListRoot
-        style={{
-          paddingLeft: 20,
-          ...style,
-        }}
-      >
-        {children}
-      </ListRoot>
-    </BulletListContext.Provider>
+    <ListRoot
+      style={{
+        paddingLeft: 20,
+        ...style,
+      }}
+    >
+      {children}
+    </ListRoot>
   );
 };
 
@@ -92,12 +73,10 @@ const BulletListItem: FC<BulletListItemProps> = ({
   size = "md",
   children,
 }) => {
-  const { size: sizeContext } = useContext(BulletListContext);
-
   const style: CSSProperties = {
     padding: "2px 0",
     ...variants[variant],
-    ...sizes[size ?? sizeContext],
+    ...sizes[size],
     ...styleProp,
   };
 

--- a/src/mailingui/components/list/BulletList.tsx
+++ b/src/mailingui/components/list/BulletList.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, { FC, CSSProperties, ReactNode } from "react";
 import { theme } from "@mailingui/themes";
 

--- a/src/mailingui/components/list/List.tsx
+++ b/src/mailingui/components/list/List.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC, CSSProperties, ReactNode, createContext, useContext } from "react";
+import { FC, CSSProperties, ReactNode } from "react";
 import { Column, Row, Text } from "@react-email/components";
 import { theme } from "@mailingui/themes";
 
@@ -43,94 +43,29 @@ const variants = {
 
 type TextVariant = keyof typeof variants;
 
-type ListContextType = {
-  direction: "vertical" | "horizontal";
-  centered: boolean;
-  size: SizeType;
-  titleSize?: SizeType;
-  titleStyle?: CSSProperties;
-  bodyStyle?: CSSProperties;
-};
-
-const ListContext = createContext<ListContextType>({
-  direction: "vertical",
-  centered: false,
-  size: "md",
-  titleSize: undefined,
-});
-
 export type ListRootProps = {
-  centered?: boolean;
-  titleSize?: SizeType;
-  size?: SizeType;
   style?: CSSProperties;
-  titleStyle?: CSSProperties;
-  bodyStyle?: CSSProperties;
   children?: ReactNode;
-  horizontal?: boolean;
 };
 
-const ListRoot: FC<ListRootProps> = ({
-  style,
-  size,
-  centered,
-  titleSize,
-  horizontal,
-  titleStyle,
-  bodyStyle,
-  children,
-}) => {
-  const contextValue: ListContextType = {
-    direction: horizontal ? "horizontal" : "vertical",
-    centered: !!centered,
-    size: size ?? "md",
-    titleSize,
-    titleStyle,
-    bodyStyle,
-  };
-
-  return (
-    <ListContext.Provider value={contextValue}>
-      <Row style={{ ...style }}>{children}</Row>
-    </ListContext.Provider>
-  );
+const ListRoot: FC<ListRootProps> = ({ style, children }) => {
+  return <Row style={{ ...style }}>{children}</Row>;
 };
-
-type ListItemContextType = {
-  variant: TextVariant;
-  size: SizeType;
-};
-
-const ListItemContext = createContext<ListItemContextType>({
-  variant: "default",
-  size: "md",
-});
 
 type ListItemProps = {
   style?: CSSProperties;
   children?: ReactNode;
-  variant?: TextVariant;
-  size?: SizeType;
+  direction?: "vertical" | "horizontal";
 };
 
 const ListItem: FC<ListItemProps> = ({
   style,
-  variant = "default",
-  size,
+  direction = "vertical",
   children,
 }) => {
-  const { direction, size: sizeContext } = useContext(ListContext);
   const Wrapper = direction === "vertical" ? Row : Column;
-
-  const itemContextValue: ListItemContextType = {
-    variant,
-    size: size ?? sizeContext,
-  };
-
   return (
-    <ListItemContext.Provider value={itemContextValue}>
-      <Wrapper style={{ verticalAlign: "top", ...style }}>{children}</Wrapper>
-    </ListItemContext.Provider>
+    <Wrapper style={{ verticalAlign: "top", ...style }}>{children}</Wrapper>
   );
 };
 
@@ -143,30 +78,21 @@ type ListItemTitleProps = {
 };
 
 const ListItemTitle: FC<ListItemTitleProps> = ({
-  centered,
-  size,
   style,
-  variant,
+  size = "md",
+  centered = false,
+  variant = "default",
   children,
 }) => {
-  const {
-    centered: centeredContext,
-    titleSize: titleSizeContext,
-    titleStyle: titleStyleContext,
-  } = useContext(ListContext);
-  const { variant: variantContext, size: sizeContext } =
-    useContext(ListItemContext);
-
   return (
     <Text
       style={{
-        textAlign: centered ?? centeredContext ? "center" : "inherit",
-        ...variants[variant ?? variantContext],
-        ...sizes[size ?? titleSizeContext ?? sizeContext],
+        textAlign: centered ? "center" : "inherit",
+        ...variants[variant],
+        ...sizes[size],
         fontWeight: 700,
         margin: 0,
         marginBottom: "4px",
-        ...titleStyleContext,
         ...style,
       }}
     >
@@ -185,25 +111,19 @@ type ListItemContentProps = {
 
 const ListItemContent: FC<ListItemContentProps> = ({
   style,
-  size,
-  centered,
-  variant,
+  size = "md",
+  centered = false,
+  variant = "default",
   children,
 }) => {
-  const { centered: centeredContext, bodyStyle: bodyStyleContext } =
-    useContext(ListContext);
-  const { variant: variantContext, size: sizeContext } =
-    useContext(ListItemContext);
-
   return (
     <Text
       style={{
-        textAlign: centered ?? centeredContext ? "center" : "inherit",
-        ...variants[variant ?? variantContext],
-        ...sizes[size ?? sizeContext],
+        textAlign: centered ? "center" : "inherit",
+        ...variants[variant],
+        ...sizes[size],
         margin: 0,
         marginBottom: "24px",
-        ...bodyStyleContext,
         ...style,
       }}
     >

--- a/src/mailingui/components/list/List.tsx
+++ b/src/mailingui/components/list/List.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { FC, CSSProperties, ReactNode } from "react";
 import { Column, Row, Text } from "@react-email/components";
 import { theme } from "@mailingui/themes";

--- a/src/mailingui/components/social-icon/SocialIcon.tsx
+++ b/src/mailingui/components/social-icon/SocialIcon.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, { FC, CSSProperties } from "react";
 import { Img, Link } from "@react-email/components";
 

--- a/src/mailingui/components/text/Text.tsx
+++ b/src/mailingui/components/text/Text.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import { Text as ReactEmailText } from "@react-email/components";
 import { theme } from "@mailingui/themes";


### PR DESCRIPTION
closes #205 

Fixes occasional problem with server side emails generation, which originates from previous 'use client' usage by mailingui email components.
In most components directive was not needed currently.
In list components contexts were removed in favor of styling child components manually. (For most props this was already available). As context was kind of DX improvement (common styling could be done on list root level) it would be nice to explore context alternatives later.

Reviewed that with this fix, server api side rendering of emails should work ('use client' was blocking) and react.email preview mode too (context in List components was blocking)