### PR TITLE
feat: Pass Theme to IconRow and introduce Cell Alignment

### DIFF
--- a/src/mailingui/components/grid/Grid.tsx
+++ b/src/mailingui/components/grid/Grid.tsx
@@ -27,6 +27,7 @@ const Cell: React.FC<React.PropsWithChildren<CellProps>> = ({
         width: `calc(${breakpoint ** 2}px - ${breakpoint * 100}%)`,
         verticalAlign: align,
       }}
+      width={`${minWidth}%`}
     >
       {children}
     </Column>

--- a/src/mailingui/components/grid/Grid.tsx
+++ b/src/mailingui/components/grid/Grid.tsx
@@ -7,12 +7,14 @@ const GAP = 4;
 type CellProps = {
   width?: number;
   breakpoint?: number;
+  align?: "top" | "middle" | "bottom";
   gap?: number;
 };
 
 const Cell: React.FC<React.PropsWithChildren<CellProps>> = ({
   width = 50,
   breakpoint = BREAKPOINT,
+  align = "middle",
   children,
 }) => {
   const minWidth = width > 100 ? 100 : width;
@@ -23,6 +25,7 @@ const Cell: React.FC<React.PropsWithChildren<CellProps>> = ({
         minWidth: `${minWidth}%`,
         maxWidth: "100%",
         width: `calc(${breakpoint ** 2}px - ${breakpoint * 100}%)`,
+        verticalAlign: align,
       }}
     >
       {children}

--- a/src/mailingui/components/icon-row/IconRow.tsx
+++ b/src/mailingui/components/icon-row/IconRow.tsx
@@ -1,6 +1,7 @@
 import { Column, Row } from "@react-email/components";
 import * as React from "react";
 import { Img, Link } from "../typography/Typography";
+import { Theme } from "@mailingui/themes";
 
 export const IconRow: React.FC<{
   compact?: boolean;
@@ -13,6 +14,7 @@ export const IconRow: React.FC<{
   }[];
   iconGap?: Extract<React.CSSProperties["gap"], number>;
   iconWidth?: Extract<React.CSSProperties["width"], number>;
+  theme?: Theme;
 }> = ({
   compact = false,
   align = "left",
@@ -20,6 +22,7 @@ export const IconRow: React.FC<{
   icons,
   iconGap = 16,
   iconWidth = 24,
+  theme,
 }) => {
   const colWidth = iconWidth + iconGap;
   return (
@@ -36,8 +39,9 @@ export const IconRow: React.FC<{
           }}
           width={fullWidth ? `${100 / icons.length - 1}%` : undefined}
         >
-          <Link style={{ textDecoration: "none" }} href={href}>
+          <Link theme={theme} style={{ textDecoration: "none" }} href={href}>
             <Img
+              theme={theme}
               compact={compact || Boolean(text)}
               caption={text}
               width={iconWidth}

--- a/src/mailingui/components/icon-row/IconRow.tsx
+++ b/src/mailingui/components/icon-row/IconRow.tsx
@@ -28,7 +28,11 @@ export const IconRow: React.FC<{
   return (
     <Row
       align={align}
-      style={{ width: fullWidth ? "100%" : colWidth * icons.length }}
+      style={{
+        width: fullWidth ? "100%" : colWidth * icons.length,
+        margin: "auto",
+      }}
+      width={fullWidth ? "100%" : colWidth * icons.length}
     >
       {icons.map(({ href, src, text }, i) => (
         <Column
@@ -37,13 +41,13 @@ export const IconRow: React.FC<{
           style={{
             paddingRight: fullWidth || i === icons.length - 1 ? 0 : iconGap,
           }}
-          width={fullWidth ? `${100 / icons.length - 1}%` : undefined}
+          width={fullWidth ? `${100 / icons.length - 1}%` : iconWidth}
         >
           <Link theme={theme} style={{ textDecoration: "none" }} href={href}>
             <Img
-              theme={theme}
-              compact={compact || Boolean(text)}
               caption={text}
+              compact={compact || Boolean(text)}
+              theme={theme}
               width={iconWidth}
               src={src}
             />


### PR DESCRIPTION
IconRow has previously inherited default theme for Img and Link without a way to update it, this fixes it by passing a theme to IconRow component.
Cells could not be aligned, added a `align` prop to the component.
Added IconRow and Cell `width` properties to better compatibility with outlook.