### PR TITLE
fix: IconRow Padding in Outlook

### DIFF
--- a/src/mailingui/components/icon-row/IconRow.tsx
+++ b/src/mailingui/components/icon-row/IconRow.tsx
@@ -44,6 +44,7 @@ export const IconRow: React.FC<{
           key={i}
           style={{
             paddingRight: fullWidth || i === icons.length - 1 ? 0 : iconGap,
+            paddingBottom: pb,
           }}
           width={fullWidth ? `${100 / icons.length - 1}%` : iconWidth}
         >
@@ -51,9 +52,7 @@ export const IconRow: React.FC<{
             theme={theme}
             style={{
               textDecoration: "none",
-              display: "inline-block",
               margin: 0,
-              paddingBottom: pb,
             }}
             href={href}
           >

--- a/src/mailingui/components/icon-row/IconRow.tsx
+++ b/src/mailingui/components/icon-row/IconRow.tsx
@@ -52,6 +52,7 @@ export const IconRow: React.FC<{
             style={{
               textDecoration: "none",
               display: "inline-block",
+              margin: 0,
               paddingBottom: pb,
             }}
             href={href}

--- a/src/mailingui/components/icon-row/IconRow.tsx
+++ b/src/mailingui/components/icon-row/IconRow.tsx
@@ -15,7 +15,7 @@ export const IconRow: React.FC<{
   iconGap?: Extract<React.CSSProperties["gap"], number>;
   iconWidth?: Extract<React.CSSProperties["width"], number>;
   iconHeight?: Extract<React.CSSProperties["height"], number>;
-  pb?: string | number;
+  paddingBottom?: string | number;
   theme?: Theme;
 }> = ({
   compact = false,
@@ -25,7 +25,7 @@ export const IconRow: React.FC<{
   iconGap = 16,
   iconWidth = 24,
   iconHeight = iconWidth,
-  pb,
+  paddingBottom,
   theme,
 }) => {
   const colWidth = iconWidth + iconGap;
@@ -44,7 +44,7 @@ export const IconRow: React.FC<{
           key={i}
           style={{
             paddingRight: fullWidth || i === icons.length - 1 ? 0 : iconGap,
-            paddingBottom: pb,
+            paddingBottom,
           }}
           width={fullWidth ? `${100 / icons.length - 1}%` : iconWidth}
         >

--- a/src/mailingui/components/icon-row/IconRow.tsx
+++ b/src/mailingui/components/icon-row/IconRow.tsx
@@ -1,7 +1,7 @@
 import { Column, Row } from "@react-email/components";
 import * as React from "react";
 import { Img, Link } from "../typography/Typography";
-import { Theme } from "@mailingui/themes";
+import { Theme } from "../../themes";
 
 export const IconRow: React.FC<{
   compact?: boolean;
@@ -14,6 +14,7 @@ export const IconRow: React.FC<{
   }[];
   iconGap?: Extract<React.CSSProperties["gap"], number>;
   iconWidth?: Extract<React.CSSProperties["width"], number>;
+  iconHeight?: Extract<React.CSSProperties["height"], number>;
   theme?: Theme;
 }> = ({
   compact = false,
@@ -22,6 +23,7 @@ export const IconRow: React.FC<{
   icons,
   iconGap = 16,
   iconWidth = 24,
+  iconHeight = iconWidth,
   theme,
 }) => {
   const colWidth = iconWidth + iconGap;
@@ -49,6 +51,7 @@ export const IconRow: React.FC<{
               compact={compact || Boolean(text)}
               theme={theme}
               width={iconWidth}
+              height={iconHeight}
               src={src}
             />
           </Link>

--- a/src/mailingui/components/icon-row/IconRow.tsx
+++ b/src/mailingui/components/icon-row/IconRow.tsx
@@ -25,7 +25,7 @@ export const IconRow: React.FC<{
   iconGap = 16,
   iconWidth = 24,
   iconHeight = iconWidth,
-  pb = 16,
+  pb,
   theme,
 }) => {
   const colWidth = iconWidth + iconGap;
@@ -51,6 +51,7 @@ export const IconRow: React.FC<{
             theme={theme}
             style={{
               textDecoration: "none",
+              display: "inline-block",
               paddingBottom: pb,
             }}
             href={href}

--- a/src/mailingui/components/icon-row/IconRow.tsx
+++ b/src/mailingui/components/icon-row/IconRow.tsx
@@ -15,6 +15,7 @@ export const IconRow: React.FC<{
   iconGap?: Extract<React.CSSProperties["gap"], number>;
   iconWidth?: Extract<React.CSSProperties["width"], number>;
   iconHeight?: Extract<React.CSSProperties["height"], number>;
+  pb?: string | number;
   theme?: Theme;
 }> = ({
   compact = false,
@@ -24,6 +25,7 @@ export const IconRow: React.FC<{
   iconGap = 16,
   iconWidth = 24,
   iconHeight = iconWidth,
+  pb = 16,
   theme,
 }) => {
   const colWidth = iconWidth + iconGap;
@@ -45,7 +47,14 @@ export const IconRow: React.FC<{
           }}
           width={fullWidth ? `${100 / icons.length - 1}%` : iconWidth}
         >
-          <Link theme={theme} style={{ textDecoration: "none" }} href={href}>
+          <Link
+            theme={theme}
+            style={{
+              textDecoration: "none",
+              paddingBottom: pb,
+            }}
+            href={href}
+          >
             <Img
               caption={text}
               compact={compact || Boolean(text)}

--- a/src/mailingui/components/typography/Typography.tsx
+++ b/src/mailingui/components/typography/Typography.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable @next/next/no-img-element */
 import * as React from "react";
 
-import { Theme } from "@mailingui/themes";
-import { cx } from "@mailingui/utils";
+import { Theme } from "../../themes";
+import { cx } from "../../utils";
+import { Column, Row } from "@react-email/components";
 
 const H1: React.FC<
   React.ComponentPropsWithoutRef<"h1"> & {
@@ -165,7 +166,8 @@ const Img: React.FC<
 > = ({ caption, compact, theme, alt, src, width, height, style, ...props }) => {
   if (!caption)
     return (
-      <img
+      <Row
+        width={width}
         style={cx(
           [
             "global",
@@ -178,34 +180,38 @@ const Img: React.FC<
             theme,
           }
         )}
-        alt={alt}
-        src={src}
-        width={width}
-        height={height}
-        {...props}
-      />
+      >
+        <Column>
+          <img alt={alt} src={src} width={width} height={height} {...props} />
+        </Column>
+      </Row>
     );
   return (
     <figure style={cx(["figure"], { theme })}>
-      <img
+      <Row
+        width={width}
         style={cx(
           [
             "global",
             "img",
             Boolean(caption) && "compact",
+            Boolean(caption) && {
+              marginBottom: 0,
+              paddingBottom: 0,
+            },
             compact && "compact",
+            { height },
             style,
           ],
           {
             theme,
           }
         )}
-        alt={alt}
-        src={src}
-        width={width}
-        height={height}
-        {...props}
-      />
+      >
+        <Column height={height}>
+          <img alt={alt} src={src} width={width} height={height} {...props} />
+        </Column>
+      </Row>
 
       <figcaption
         style={cx(

--- a/src/mailingui/components/typography/Typography.tsx
+++ b/src/mailingui/components/typography/Typography.tsx
@@ -166,8 +166,12 @@ const Img: React.FC<
 > = ({ caption, compact, theme, alt, src, width, height, style, ...props }) => {
   if (!caption)
     return (
-      <Row
+      <img
+        alt={alt}
+        src={src}
         width={width}
+        height={height}
+        {...props}
         style={cx(
           [
             "global",
@@ -180,11 +184,7 @@ const Img: React.FC<
             theme,
           }
         )}
-      >
-        <Column>
-          <img alt={alt} src={src} width={width} height={height} {...props} />
-        </Column>
-      </Row>
+      />
     );
   return (
     <figure style={cx(["figure"], { theme })}>

--- a/src/mailingui/themes/theme.ts
+++ b/src/mailingui/themes/theme.ts
@@ -169,7 +169,7 @@ export const theme: Theme = {
     textDecoration: "none",
   },
   figcaption: {
-    marginTop: `${remToPx(0.5)}`,
+    paddingTop: `${remToPx(0.5)}`,
     textAlign: "center",
   },
   muted: {


### PR DESCRIPTION
Due to Outlook not supporting nor margin and padding on the `img` element, I have wrapped it in a table and passed the styles there, this does not break the designs, however we should use padding where possible in the future (I have used it here for figcaption - updated theme).